### PR TITLE
Bump clickhouse-rs, enable rustls-tls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `rustls-tls`, `native-tls` features so that the library can work with HTTPS
 
 ## [0.1.7] - 2024-08-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `rustls-tls`, `native-tls` features so that the library can work with HTTPS
+- `rustls-tls` feature is enabled by default so that the library can work with HTTPS. Optionally, it is also possible to use `native-tls` instead.
 
 ## [0.1.7] - 2024-08-08
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,13 @@ edition = "2021"
 name = "ch2rs"
 path = "bin/ch2rs.rs"
 
+[features]
+rustls-tls = ["clickhouse/rustls-tls"]
+native-tls = ["clickhouse/native-tls"]
+
 [dependencies]
 anyhow = "1.0.40"
-clickhouse = { version = "0.12.2", features = ["rustls-tls"] }
+clickhouse =  "0.12.2"
 heck = "0.5.0"
 serde = { version = "1.0.126", features = ["derive"] }
 structopt = "0.3.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "bin/ch2rs.rs"
 
 [dependencies]
 anyhow = "1.0.40"
-clickhouse = "0.12.1"
+clickhouse = { version = "0.12.2", features = ["rustls-tls"] }
 heck = "0.5.0"
 serde = { version = "1.0.126", features = ["derive"] }
 structopt = "0.3.21"
@@ -27,4 +27,4 @@ serde_repr = "0.1.7"
 serde_bytes = "0.11.5"
 trybuild = "1.0.42"
 uuid = "1.2.1"
-clickhouse = { version = "0.12.1", features = ["uuid"] }
+clickhouse = { version = "0.12.2", features = ["uuid"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ name = "ch2rs"
 path = "bin/ch2rs.rs"
 
 [features]
+default = ["rustls-tls"]
 rustls-tls = ["clickhouse/rustls-tls"]
 native-tls = ["clickhouse/native-tls"]
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ An auxiliary utility for generating Rust structures from ClickHouse DB schemas f
 cargo install ch2rs
 ```
 
-When working with HTTPS URLs, install the crate with either `rustls-tls` or `native-tls` feature:
+The crate enables `rustls-tls` [client](https://github.com/ClickHouse/clickhouse-rs/blob/main/Cargo.toml) feature by default, which allows to work with HTTPS URLs. 
+If `rustls-tls` does not work in your use case, you can install the crate with `native-tls` instead:
 
 ```sh
-cargo install ch2rs --features rustls-tls
+cargo install ch2rs --features native-tls
 ```
 
 ### Help

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An auxiliary utility for generating Rust structures from ClickHouse DB schemas f
 cargo install ch2rs
 ```
 
-When working with an HTTPS URLs, install the crate with either `rustls-tls` or `native-tls` feature:
+When working with HTTPS URLs, install the crate with either `rustls-tls` or `native-tls` feature:
 
 ```sh
 cargo install ch2rs --features rustls-tls

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ An auxiliary utility for generating Rust structures from ClickHouse DB schemas f
 cargo install ch2rs
 ```
 
+When working with an HTTPS URLs, install the crate with either `rustls-tls` or `native-tls` feature:
+
+```sh
+cargo install ch2rs --features rustls-tls
+```
+
 ### Help
 
 ```sh


### PR DESCRIPTION
Exposes the `native-tls`, `rustls-tls` features so that the library can work with HTTPS.

`rustls-tls` feature is enabled by default. 

Fixes #6 