### PR TITLE
publish to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,35 +15,48 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: cargo build --all-targets --all-features
+      - uses: actions/checkout@v2
+      - run: cargo build --all-targets --all-features
 
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: rustup component add rustfmt
-    - run: cargo fmt --version
-    - run: cargo fmt -- --check
+      - uses: actions/checkout@v2
+      - run: rustup component add rustfmt
+      - run: cargo fmt --version
+      - run: cargo fmt -- --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: rustup component add clippy
-    - run: cargo clippy --version
-    - run: cargo clippy
-    - run: cargo clippy --all-targets --all-features
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - run: cargo clippy --version
+      - run: cargo clippy
+      - run: cargo clippy --all-targets --all-features
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: cargo test
-    - run: cargo test --all-features
+      - uses: actions/checkout@v2
+      - run: cargo test
+      - run: cargo test --all-features
 
     services:
       clickhouse:
         image: clickhouse/clickhouse-server
         ports:
           - 8123:8123
+
+  artifact:
+    runs-on: ubuntu-latest
+    needs: [build, rustfmt, clippy, test]
+    steps:
+      - name: Upload CI Success
+        run: echo "CI passed" > ci_success.txt
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-success
+          path: ci_success.txt
+          retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release to crates.io
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # Matches tags like v1.0.0, v2.1.3, etc.
+
+jobs:
+  crates_io_publish:
+    name: Publish (crates.io)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Check the CI success artifact to ensure CI has passed
+      - name: CI success artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ci-success
+
+      - name: Cache Cargo Release
+        id: cargo_release_cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-release
+          key: ${{ runner.os }}-cargo-release
+
+      - run: cargo install cargo-release
+        if: steps.cargo_release_cache.outputs.cache-hit != 'true'
+
+      - name: cargo login
+        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
+
+      - name: "cargo release publish"
+        run: |-
+          cargo release \
+            publish \
+            --workspace \
+            --all-features \
+            --allow-branch HEAD \
+            --no-confirm \
+            --execute

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ ARGS:
     <table>    The table's name
 ```
 
+### Release
+
+```
+$ git tag $tag; 
+$ git push origin $tag  ## this will publish if conditions match
+
+```
+
 ## Examples
 
 See [snapshots](tests/snapshots).


### PR DESCRIPTION
- This should allow `git tag $tag` & `git push origin $tag` for repository maintainers (should work for the team). It also checks on CI successful run (using `Upload artifact`, if it'll work)
- We still need to add `CRATES_IO_API_TOKEN` in the repo, not sure as when I try to login with github, it asks for permission to our org data 👎 
- I haven't changed anything around branching convention, as I'm not sure if this fits **our** requirement for artefact release.